### PR TITLE
add merge conflict labelling workflow

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,29 @@
+name: Label Merge Conflicts
+
+on:
+  push:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PRs with merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "PR has merge conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: |
+            ⚠️ **This PR has merge conflicts.**
+
+            Please resolve the merge conflicts before review.
+
+            Your PR will only be reviewed by a maintainer after all conflicts have been resolved.
+
+            📺 Watch this video to understand why conflicts occur and how to resolve them:
+            https://www.youtube.com/watch?v=Sqsz1-o7nXk


### PR DESCRIPTION
### Addressed Issues:
<!-- Link the issue this PR addresses -->
This PR introduces an automated workflow that labels pull requests with merge conflicts using eps1lon/actions-label-merge-conflict.

When a PR has merge conflicts:

A label “PR has merge conflicts” is automatically added.
A comment is posted notifying the contributor.
The label is automatically removed once conflicts are resolved.

#### Why This Change?
Currently, maintainers must manually identify and notify contributors when their PR requires rebasing. This creates unnecessary review overhead and delays.

This workflow:

- Improves PR triage visibility
- Notifies contributors immediately when conflicts arise
- Reduces manual maintainer intervention
- Ensures PRs are conflict-free before review

Behavior
When merge conflicts appear:
Label added: PR has merge conflicts
>Comment posted:
⚠️ This PR has merge conflicts.
Please resolve the merge conflicts before review.
Your PR will only be reviewed by a maintainer after all conflicts have been resolved.
Watch this video to understand why conflicts occur and how to resolve them.

When conflicts are resolved:
Label is automatically removed.

### Summary:
<!-- Explain what changed and why -->

### Contract Scope:
<!-- List affected contracts/libraries/scripts/tests -->

### Security Considerations:
<!-- Note trust assumptions, auth model changes, and new attack surfaces -->

### Storage/Layout Impact:
<!-- Required for upgradeable patterns and ABI/storage compatibility -->
- [ ] No storage layout changes
- [ ] Storage layout changed (explain below)

### Gas and Performance:
<!-- Mention expected gas impact and include notable changes -->

### Test Evidence:
<!-- Paste short output snippets or links to CI runs -->
- `forge fmt --check`:
- `forge build --sizes`:
- `forge test -vvv`:
- `forge coverage`:
- `forge snapshot`:

### Deployment and Verification:
<!-- Describe script/network/env changes and explorer verification status -->
- [ ] Requires deployment script updates
- [ ] Requires env/config updates (`PRIVATE_KEY`, RPC URL, explorer key)
- [ ] Requires explorer verification updates
- [ ] No deployment impact

### Screenshots/Recordings:
<!-- If applicable, add screenshots or recordings to demonstrate the changes -->

### Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions.
- [x] If applicable, I have made corresponding changes or additions to the documentation.
- [x] If applicable, I have made corresponding changes or additions to tests.
- [x] My changes generate no new warnings or errors.
- [x] I have joined the Stability Nexus's [Discord server](https://discord.gg/eqYhuFzuKN) and I will share a link to this PR with the project maintainers there.
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I reviewed contract access control and authorization paths.
- [x] I reviewed reentrancy/external-call ordering where relevant.
- [x] I confirmed storage compatibility (or documented intentional breakage).
- [x] I reviewed gas impact for hot paths.

## AI Usage Disclosure

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO

### AI Notice - Important!

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.
